### PR TITLE
Use ephemeral key pairs when performing handshake

### DIFF
--- a/cplusplus/include/autograph.h
+++ b/cplusplus/include/autograph.h
@@ -143,18 +143,16 @@ struct HandshakeResult {
   Handshake handshake;
 };
 
-using HandshakeFunction = std::function<HandshakeResult(const Bytes, const Bytes)>;
+using HandshakeFunction = std::function<HandshakeResult(KeyPair &, const Bytes, const Bytes)>;
 
 struct Party {
   SafetyNumberFunction calculate_safety_number;
   HandshakeFunction perform_handshake;
 };
 
-Party create_initiator(const KeyPair identity_key_pair,
-                       KeyPair ephemeral_key_pair);
+Party create_initiator(const KeyPair identity_key_pair);
 
-Party create_responder(const KeyPair identity_key_pair,
-                       KeyPair ephemeral_key_pair);
+Party create_responder(const KeyPair identity_key_pair);
 
 KeyPairResult generate_ephemeral_key_pair();
 

--- a/cplusplus/include/autograph/internal.h
+++ b/cplusplus/include/autograph/internal.h
@@ -6,11 +6,9 @@
 namespace autograph {
 
 HandshakeFunction create_handshake(const bool is_initiator,
-                                   const KeyPair identity_key_pair,
-                                   KeyPair ephemeral_key_pair);
+                                   const KeyPair identity_key_pair);
 
-Party create_party(const bool is_initiator, const KeyPair identity_key_pair,
-                   KeyPair ephemeral_key_pair);
+Party create_party(const bool is_initiator, const KeyPair identity_key_pair);
 
 SafetyNumberFunction create_safety_number(const Bytes our_identity_key);
 

--- a/cplusplus/src/autograph.cpp
+++ b/cplusplus/src/autograph.cpp
@@ -2,14 +2,12 @@
 
 namespace autograph {
 
-Party create_initiator(const KeyPair identity_key_pair,
-                       KeyPair ephemeral_key_pair) {
-  return create_party(true, identity_key_pair, ephemeral_key_pair);
+Party create_initiator(const KeyPair identity_key_pair) {
+  return create_party(true, identity_key_pair);
 }
 
-Party create_responder(const KeyPair identity_key_pair,
-                       KeyPair ephemeral_key_pair) {
-  return create_party(false, identity_key_pair, ephemeral_key_pair);
+Party create_responder(const KeyPair identity_key_pair) {
+  return create_party(false, identity_key_pair);
 }
 
 KeyPair create_key_pair() {

--- a/cplusplus/src/handshake.cpp
+++ b/cplusplus/src/handshake.cpp
@@ -3,12 +3,12 @@
 namespace autograph {
 
 HandshakeFunction create_handshake(const bool is_initiator,
-                                   const KeyPair our_identity_key_pair,
-                                   KeyPair our_ephemeral_key_pair) {
-  auto perform_handshake = [is_initiator, our_identity_key_pair,
-                            our_ephemeral_key_pair](
+                                   const KeyPair our_identity_key_pair) {
+  auto perform_handshake = [is_initiator, our_identity_key_pair](
+                              KeyPair &our_ephemeral_key_pair,
                                const Bytes their_identity_key,
-                               const Bytes their_ephemeral_key) {
+                               const Bytes their_ephemeral_key
+                               ) {
     Bytes transcript(128);
     Bytes our_secret_key(32);
     Bytes their_secret_key(32);
@@ -18,7 +18,7 @@ HandshakeFunction create_handshake(const bool is_initiator,
         their_secret_key.data(), is_initiator ? 1 : 0,
         our_identity_key_pair.private_key.data(),
         our_identity_key_pair.public_key.data(),
-        const_cast<unsigned char*>(our_ephemeral_key_pair.private_key.data()),
+        our_ephemeral_key_pair.private_key.data(),
         our_ephemeral_key_pair.public_key.data(), their_identity_key.data(),
         their_ephemeral_key.data()) == 0;
     SessionFunction establish_session =

--- a/cplusplus/src/party.cpp
+++ b/cplusplus/src/party.cpp
@@ -2,12 +2,11 @@
 
 namespace autograph {
 
-Party create_party(const bool is_initiator, const KeyPair identity_key_pair,
-                   KeyPair ephemeral_key_pair) {
+Party create_party(const bool is_initiator, const KeyPair identity_key_pair) {
   auto calculate_safety_number =
       create_safety_number(identity_key_pair.public_key);
   auto perform_handshake =
-      create_handshake(is_initiator, identity_key_pair, ephemeral_key_pair);
+      create_handshake(is_initiator, identity_key_pair);
   Party party = {
       calculate_safety_number,
       perform_handshake,

--- a/cplusplus/tests/handshake.cpp
+++ b/cplusplus/tests/handshake.cpp
@@ -53,17 +53,14 @@ TEST_CASE("Handshake", "[handshake]") {
 
   autograph::init();
 
-  auto alice = autograph::create_initiator(alice_identity_key_pair,
-                                           alice_ephemeral_key_pair);
-  auto bob = autograph::create_responder(bob_identity_key_pair,
-                                         bob_ephemeral_key_pair);
+  auto alice = autograph::create_initiator(alice_identity_key_pair);
+  auto bob = autograph::create_responder(bob_identity_key_pair);
 
-  auto alice_result = alice.perform_handshake(bob_identity_key_pair.public_key,
+  auto alice_result = alice.perform_handshake(alice_ephemeral_key_pair, bob_identity_key_pair.public_key,
                                    bob_ephemeral_key_pair.public_key);
-  auto bob_result = bob.perform_handshake(alice_identity_key_pair.public_key,
+  auto bob_result = bob.perform_handshake(bob_ephemeral_key_pair, alice_identity_key_pair.public_key,
                                  alice_ephemeral_key_pair.public_key);
 
-  
   REQUIRE(alice_result.success == true);
   REQUIRE(bob_result.success == true);
   REQUIRE_THAT(alice_result.handshake.message, Catch::Matchers::Equals(alice_message));

--- a/cplusplus/tests/safety_number.cpp
+++ b/cplusplus/tests/safety_number.cpp
@@ -43,10 +43,8 @@ TEST_CASE("Safety number", "[safety_number]") {
 
   autograph::init();
 
-  auto alice = autograph::create_initiator(alice_identity_key_pair,
-                                           alice_ephemeral_key_pair);
-  auto bob = autograph::create_responder(bob_identity_key_pair,
-                                         bob_ephemeral_key_pair);
+  auto alice = autograph::create_initiator(alice_identity_key_pair);
+  auto bob = autograph::create_responder(bob_identity_key_pair);
 
   auto a = alice.calculate_safety_number(bob_identity_key_pair.public_key);
   auto b = bob.calculate_safety_number(alice_identity_key_pair.public_key);

--- a/cplusplus/tests/session.cpp
+++ b/cplusplus/tests/session.cpp
@@ -113,14 +113,12 @@ TEST_CASE("Session", "[session]") {
 
   autograph::init();
 
-  auto alice = autograph::create_initiator(alice_identity_key_pair,
-                                           alice_ephemeral_key_pair);
-  auto bob = autograph::create_responder(bob_identity_key_pair,
-                                         bob_ephemeral_key_pair);
+  auto alice = autograph::create_initiator(alice_identity_key_pair);
+  auto bob = autograph::create_responder(bob_identity_key_pair);
 
-  auto alice_handshake = alice.perform_handshake(
+  auto alice_handshake = alice.perform_handshake(alice_ephemeral_key_pair,
       bob_identity_key_pair.public_key, bob_ephemeral_key_pair.public_key).handshake;
-  auto bob_handshake = bob.perform_handshake(
+  auto bob_handshake = bob.perform_handshake(bob_ephemeral_key_pair,
       alice_identity_key_pair.public_key, alice_ephemeral_key_pair.public_key).handshake;
 
   auto a = alice_handshake.establish_session(bob_handshake.message).session;

--- a/swift/Sources/Autograph/Autograph.swift
+++ b/swift/Sources/Autograph/Autograph.swift
@@ -7,24 +7,20 @@ public struct Autograph {
   }
 
   public func createInitiator(
-    identityKeyPair: KeyPair,
-    ephemeralKeyPair: KeyPair
+    identityKeyPair: KeyPair
   ) -> Party {
     createParty(
       isInitiator: true,
-      identityKeyPair: identityKeyPair,
-      ephemeralKeyPair: ephemeralKeyPair
+      identityKeyPair: identityKeyPair
     )
   }
 
   public func createResponder(
-    identityKeyPair: KeyPair,
-    ephemeralKeyPair: KeyPair
+    identityKeyPair: KeyPair
   ) -> Party {
     createParty(
       isInitiator: false,
-      identityKeyPair: identityKeyPair,
-      ephemeralKeyPair: ephemeralKeyPair
+      identityKeyPair: identityKeyPair
     )
   }
 

--- a/swift/Sources/Autograph/Handshake.swift
+++ b/swift/Sources/Autograph/Handshake.swift
@@ -3,14 +3,12 @@ import Foundation
 
 internal func createHandshake(
   isInitiator: Bool,
-  identityKeyPair: KeyPair,
-  ephemeralKeyPair: KeyPair
+  identityKeyPair: KeyPair
 ) -> HandshakeFunction {
   let performHandshake: HandshakeFunction = { [
     isInitiator,
-    identityKeyPair,
-    ephemeralKeyPair
-  ] theirIdentityKey, theirEphemeralKey in
+    identityKeyPair
+  ] ephemeralKeyPair, theirIdentityKey, theirEphemeralKey in
     var ourCiphertext = createHandshakeBytes()
     var transcript = createTranscriptBytes()
     var ourSecretKey = createSecretKeyBytes()

--- a/swift/Sources/Autograph/Party.swift
+++ b/swift/Sources/Autograph/Party.swift
@@ -2,15 +2,13 @@ import Foundation
 
 internal func createParty(
   isInitiator: Bool,
-  identityKeyPair: KeyPair,
-  ephemeralKeyPair: KeyPair
+  identityKeyPair: KeyPair
 ) -> Party {
   let calculateSafetyNumber =
     createSafetyNumber(ourIdentityKey: identityKeyPair.publicKey)
   let performHandshake = createHandshake(
     isInitiator: isInitiator,
-    identityKeyPair: identityKeyPair,
-    ephemeralKeyPair: ephemeralKeyPair
+    identityKeyPair: identityKeyPair
   )
   return Party(
     calculateSafetyNumber: calculateSafetyNumber,

--- a/swift/Sources/Autograph/Types.swift
+++ b/swift/Sources/Autograph/Types.swift
@@ -120,7 +120,8 @@ public class HandshakeResult {
   }
 }
 
-public typealias HandshakeFunction = (Bytes, Bytes) -> HandshakeResult
+public typealias HandshakeFunction = (inout KeyPair, Bytes, Bytes)
+  -> HandshakeResult
 
 public class Party {
   var calculateSafetyNumber: SafetyNumberFunction

--- a/swift/Tests/AutographTests/HandshakeTests.swift
+++ b/swift/Tests/AutographTests/HandshakeTests.swift
@@ -69,14 +69,6 @@ final class HandshakeTests: XCTestCase {
     4,
     33,
   ])
-  let aliceEphemeralKeyPair = KeyPair(
-    privateKey: [171, 243, 152, 144, 76, 145, 84, 13, 243, 173, 102,
-                 244, 84, 223, 43, 104, 182, 128, 230, 247, 121, 221,
-                 222, 203, 10, 80, 43, 88, 177, 155, 1, 114],
-    publicKey: [16, 9, 47, 109, 23, 19, 165, 137, 95, 186, 203,
-                186, 154, 179, 116, 3, 160, 119, 225, 180, 226, 19,
-                172, 45, 113, 125, 124, 86, 94, 159, 161, 119]
-  )
   let bobIdentityKeyPair = KeyPair(
     privateKey: [243, 11, 156, 139, 99, 129, 212, 8, 60, 53, 111, 123, 69, 158,
                  83, 255,
@@ -118,14 +110,6 @@ final class HandshakeTests: XCTestCase {
       138,
     ]
   )
-  let bobEphemeralKeyPair = KeyPair(
-    privateKey: [252, 67, 175, 250, 230, 100, 145, 82, 139, 125, 242,
-                 5, 40, 8, 155, 104, 37, 224, 5, 96, 105, 46,
-                 42, 202, 158, 63, 177, 43, 112, 184, 207, 85],
-    publicKey: [249, 212, 82, 190, 253, 45, 230, 86, 74, 150, 239,
-                0, 26, 41, 131, 245, 177, 87, 106, 105, 167, 58,
-                158, 184, 244, 65, 205, 42, 40, 80, 134, 52]
-  )
   let aliceMessage: Bytes = [
     157, 61, 99, 76, 123, 207, 247, 194, 32, 224, 244, 148, 38, 107,
     158, 13, 66, 237, 6, 32, 9, 98, 120, 172, 63, 45, 144, 194,
@@ -145,25 +129,43 @@ final class HandshakeTests: XCTestCase {
   var autograph: Autograph!
   var alice: Party!
   var bob: Party!
+  var aliceEphemeralKeyPair: KeyPair!
+  var bobEphemeralKeyPair: KeyPair!
 
   override func setUp() {
     autograph = Autograph()
     alice = autograph.createInitiator(
-      identityKeyPair: aliceIdentityKeyPair,
-      ephemeralKeyPair: aliceEphemeralKeyPair
+      identityKeyPair: aliceIdentityKeyPair
     )
     bob = autograph.createResponder(
-      identityKeyPair: bobIdentityKeyPair,
-      ephemeralKeyPair: bobEphemeralKeyPair
+      identityKeyPair: bobIdentityKeyPair
+    )
+    aliceEphemeralKeyPair = KeyPair(
+      privateKey: [171, 243, 152, 144, 76, 145, 84, 13, 243, 173, 102,
+                   244, 84, 223, 43, 104, 182, 128, 230, 247, 121, 221,
+                   222, 203, 10, 80, 43, 88, 177, 155, 1, 114],
+      publicKey: [16, 9, 47, 109, 23, 19, 165, 137, 95, 186, 203,
+                  186, 154, 179, 116, 3, 160, 119, 225, 180, 226, 19,
+                  172, 45, 113, 125, 124, 86, 94, 159, 161, 119]
+    )
+    bobEphemeralKeyPair = KeyPair(
+      privateKey: [252, 67, 175, 250, 230, 100, 145, 82, 139, 125, 242,
+                   5, 40, 8, 155, 104, 37, 224, 5, 96, 105, 46,
+                   42, 202, 158, 63, 177, 43, 112, 184, 207, 85],
+      publicKey: [249, 212, 82, 190, 253, 45, 230, 86, 74, 150, 239,
+                  0, 26, 41, 131, 245, 177, 87, 106, 105, 167, 58,
+                  158, 184, 244, 65, 205, 42, 40, 80, 134, 52]
     )
   }
 
   func testPerformHandshake() {
     let a = alice.performHandshake(
+      &aliceEphemeralKeyPair,
       bobIdentityKeyPair.publicKey,
       bobEphemeralKeyPair.publicKey
     )
     let b = bob.performHandshake(
+      &bobEphemeralKeyPair,
       aliceIdentityKeyPair.publicKey,
       aliceEphemeralKeyPair.publicKey
     )

--- a/swift/Tests/AutographTests/SafetyNumberTests.swift
+++ b/swift/Tests/AutographTests/SafetyNumberTests.swift
@@ -195,12 +195,10 @@ final class SafetyNumberTests: XCTestCase {
   override func setUp() {
     autograph = Autograph()
     alice = autograph.createInitiator(
-      identityKeyPair: aliceIdentityKeyPair,
-      ephemeralKeyPair: aliceEphemeralKeyPair
+      identityKeyPair: aliceIdentityKeyPair
     )
     bob = autograph.createResponder(
-      identityKeyPair: bobIdentityKeyPair,
-      ephemeralKeyPair: bobEphemeralKeyPair
+      identityKeyPair: bobIdentityKeyPair
     )
   }
 

--- a/swift/Tests/AutographTests/SessionTests.swift
+++ b/swift/Tests/AutographTests/SessionTests.swift
@@ -69,14 +69,6 @@ final class SessionTests: XCTestCase {
     4,
     33,
   ])
-  let aliceEphemeralKeyPair = KeyPair(
-    privateKey: [171, 243, 152, 144, 76, 145, 84, 13, 243, 173, 102,
-                 244, 84, 223, 43, 104, 182, 128, 230, 247, 121, 221,
-                 222, 203, 10, 80, 43, 88, 177, 155, 1, 114],
-    publicKey: [16, 9, 47, 109, 23, 19, 165, 137, 95, 186, 203,
-                186, 154, 179, 116, 3, 160, 119, 225, 180, 226, 19,
-                172, 45, 113, 125, 124, 86, 94, 159, 161, 119]
-  )
   let bobIdentityKeyPair = KeyPair(
     privateKey: [243, 11, 156, 139, 99, 129, 212, 8, 60, 53, 111, 123, 69, 158,
                  83, 255,
@@ -117,14 +109,6 @@ final class SessionTests: XCTestCase {
       133,
       138,
     ]
-  )
-  let bobEphemeralKeyPair = KeyPair(
-    privateKey: [252, 67, 175, 250, 230, 100, 145, 82, 139, 125, 242,
-                 5, 40, 8, 155, 104, 37, 224, 5, 96, 105, 46,
-                 42, 202, 158, 63, 177, 43, 112, 184, 207, 85],
-    publicKey: [249, 212, 82, 190, 253, 45, 230, 86, 74, 150, 239,
-                0, 26, 41, 131, 245, 177, 87, 106, 105, 167, 58,
-                158, 184, 244, 65, 205, 42, 40, 80, 134, 52]
   )
   let aliceMessage: Bytes = [
     0, 0, 0, 1, 203, 203, 240, 117,
@@ -207,24 +191,42 @@ final class SessionTests: XCTestCase {
   var autograph: Autograph!
   var alice: Party!
   var bob: Party!
+  var aliceEphemeralKeyPair: KeyPair!
+  var bobEphemeralKeyPair: KeyPair!
   var a: Session!
   var b: Session!
 
   override func setUp() {
     autograph = Autograph()
     alice = autograph.createInitiator(
-      identityKeyPair: aliceIdentityKeyPair,
-      ephemeralKeyPair: aliceEphemeralKeyPair
+      identityKeyPair: aliceIdentityKeyPair
     )
     bob = autograph.createResponder(
-      identityKeyPair: bobIdentityKeyPair,
-      ephemeralKeyPair: bobEphemeralKeyPair
+      identityKeyPair: bobIdentityKeyPair
+    )
+    aliceEphemeralKeyPair = KeyPair(
+      privateKey: [171, 243, 152, 144, 76, 145, 84, 13, 243, 173, 102,
+                   244, 84, 223, 43, 104, 182, 128, 230, 247, 121, 221,
+                   222, 203, 10, 80, 43, 88, 177, 155, 1, 114],
+      publicKey: [16, 9, 47, 109, 23, 19, 165, 137, 95, 186, 203,
+                  186, 154, 179, 116, 3, 160, 119, 225, 180, 226, 19,
+                  172, 45, 113, 125, 124, 86, 94, 159, 161, 119]
+    )
+    bobEphemeralKeyPair = KeyPair(
+      privateKey: [252, 67, 175, 250, 230, 100, 145, 82, 139, 125, 242,
+                   5, 40, 8, 155, 104, 37, 224, 5, 96, 105, 46,
+                   42, 202, 158, 63, 177, 43, 112, 184, 207, 85],
+      publicKey: [249, 212, 82, 190, 253, 45, 230, 86, 74, 150, 239,
+                  0, 26, 41, 131, 245, 177, 87, 106, 105, 167, 58,
+                  158, 184, 244, 65, 205, 42, 40, 80, 134, 52]
     )
     let aliceHandshake = alice.performHandshake(
+      &aliceEphemeralKeyPair,
       bobIdentityKeyPair.publicKey,
       bobEphemeralKeyPair.publicKey
     ).handshake
     let bobHandshake = bob.performHandshake(
+      &bobEphemeralKeyPair,
       aliceIdentityKeyPair.publicKey,
       aliceEphemeralKeyPair.publicKey
     ).handshake

--- a/typescript/src/autograph.ts
+++ b/typescript/src/autograph.ts
@@ -35,11 +35,11 @@ const generateEphemeralKeyPair = async (): Promise<KeyPairResult> => {
   }
 }
 
-const createInitiator = (identityKeyPair: KeyPair, ephemeralKeyPair: KeyPair) =>
-  createParty(true, identityKeyPair, ephemeralKeyPair)
+const createInitiator = (identityKeyPair: KeyPair) =>
+  createParty(true, identityKeyPair)
 
-const createResponder = (identityKeyPair: KeyPair, ephemeralKeyPair: KeyPair) =>
-  createParty(false, identityKeyPair, ephemeralKeyPair)
+const createResponder = (identityKeyPair: KeyPair) =>
+  createParty(false, identityKeyPair)
 
 export {
   createInitiator,

--- a/typescript/src/handshake.ts
+++ b/typescript/src/handshake.ts
@@ -76,12 +76,12 @@ const createHandshakeResult = (
 }
 
 const createHandshake =
-  (
-    isInitiator: boolean,
-    ourIdentityKeyPair: KeyPair,
-    ourEphemeralKeyPair: KeyPair
-  ): HandshakeFunction =>
-  async (theirIdentityKey: BufferSource, theirEphemeralKey: BufferSource) => {
+  (isInitiator: boolean, ourIdentityKeyPair: KeyPair): HandshakeFunction =>
+  async (
+    ourEphemeralKeyPair: KeyPair,
+    theirIdentityKey: BufferSource,
+    theirEphemeralKey: BufferSource
+  ) => {
     const transcript = calculateTranscript(
       isInitiator,
       ourIdentityKeyPair.publicKey,

--- a/typescript/src/party.ts
+++ b/typescript/src/party.ts
@@ -2,17 +2,9 @@ import { KeyPair, Party } from '../types'
 import createHandshake from './handshake'
 import createSafetyNumber from './safety-number'
 
-const createParty = (
-  isInitiator: boolean,
-  identityKeyPair: KeyPair,
-  ephemeralKeyPair: KeyPair
-): Party => {
+const createParty = (isInitiator: boolean, identityKeyPair: KeyPair): Party => {
   const calculateSafetyNumber = createSafetyNumber(identityKeyPair.publicKey)
-  const performHandshake = createHandshake(
-    isInitiator,
-    identityKeyPair,
-    ephemeralKeyPair
-  )
+  const performHandshake = createHandshake(isInitiator, identityKeyPair)
   return {
     calculateSafetyNumber,
     performHandshake

--- a/typescript/tests/handshake.test.ts
+++ b/typescript/tests/handshake.test.ts
@@ -75,18 +75,20 @@ describe('Handshake', () => {
   let bob: Party
 
   beforeEach(() => {
-    alice = createInitiator(keyPairs.alice.identity, keyPairs.alice.ephemeral)
-    bob = createResponder(keyPairs.bob.identity, keyPairs.bob.ephemeral)
+    alice = createInitiator(keyPairs.alice.identity)
+    bob = createResponder(keyPairs.bob.identity)
   })
 
   it('should allow Alice and Bob to perform a handshake', async () => {
-    const b = await bob.performHandshake(
-      keyPairs.alice.identity.publicKey,
-      keyPairs.alice.ephemeral.publicKey
-    )
     const a = await alice.performHandshake(
+      keyPairs.alice.ephemeral,
       keyPairs.bob.identity.publicKey,
       keyPairs.bob.ephemeral.publicKey
+    )
+    const b = await bob.performHandshake(
+      keyPairs.bob.ephemeral,
+      keyPairs.alice.identity.publicKey,
+      keyPairs.alice.ephemeral.publicKey
     )
     expect(a.success).toBe(true)
     expect(b.success).toBe(true)

--- a/typescript/tests/safety-number.test.ts
+++ b/typescript/tests/safety-number.test.ts
@@ -1,9 +1,5 @@
 import { createFrom } from 'stedy/bytes'
-import {
-  createInitiator,
-  createResponder,
-  generateEphemeralKeyPair
-} from '../src/autograph'
+import { createInitiator, createResponder } from '../src/autograph'
 
 describe('Safety number', () => {
   const keyPairs = {
@@ -38,14 +34,8 @@ describe('Safety number', () => {
   ])
 
   it('should allow Alice and Bob to calculate safety numbers', async () => {
-    const alice = createInitiator(
-      keyPairs.alice,
-      (await generateEphemeralKeyPair()).keyPair
-    )
-    const bob = createResponder(
-      keyPairs.bob,
-      (await generateEphemeralKeyPair()).keyPair
-    )
+    const alice = createInitiator(keyPairs.alice)
+    const bob = createResponder(keyPairs.bob)
     const a = await alice.calculateSafetyNumber(keyPairs.bob.publicKey)
     const b = await bob.calculateSafetyNumber(keyPairs.alice.publicKey)
     expect(a.safetyNumber).toEqual(safetyNumber)

--- a/typescript/tests/session.test.ts
+++ b/typescript/tests/session.test.ts
@@ -144,20 +144,19 @@ describe('Session', () => {
   let b: Session
 
   beforeEach(async () => {
-    const alice = createInitiator(
-      keyPairs.alice.identity,
-      keyPairs.alice.ephemeral
-    )
-    const bob = createResponder(keyPairs.bob.identity, keyPairs.bob.ephemeral)
+    const alice = createInitiator(keyPairs.alice.identity)
+    const bob = createResponder(keyPairs.bob.identity)
     const handshakes = {
       alice: (
         await alice.performHandshake(
+          keyPairs.alice.ephemeral,
           keyPairs.bob.identity.publicKey,
           keyPairs.bob.ephemeral.publicKey
         )
       ).handshake,
       bob: (
         await bob.performHandshake(
+          keyPairs.bob.ephemeral,
           keyPairs.alice.identity.publicKey,
           keyPairs.alice.ephemeral.publicKey
         )

--- a/typescript/types.d.ts
+++ b/typescript/types.d.ts
@@ -51,6 +51,16 @@ export type SessionResult = {
 
 export type SessionFunction = (message: BufferSource) => Promise<SessionResult>
 
+export type KeyPair = {
+  publicKey: BufferSource
+  privateKey: BufferSource
+}
+
+export type KeyPairResult = {
+  success: boolean
+  keyPair: KeyPair
+}
+
 export type Handshake = {
   message: BufferSource
   establishSession: SessionFunction
@@ -62,19 +72,10 @@ export type HandshakeResult = {
 }
 
 export type HandshakeFunction = (
+  ourEphemeralKeyPair: KeyPair,
   theirIdentityKey: BufferSource,
   theirEphemeralKey: BufferSource
 ) => Promise<HandshakeResult>
-
-export type KeyPair = {
-  publicKey: BufferSource
-  privateKey: BufferSource
-}
-
-export type KeyPairResult = {
-  success: boolean
-  keyPair: KeyPair
-}
 
 export type Party = {
   calculateSafetyNumber: SafetyNumberFunction


### PR DESCRIPTION
This PR updates the C++, Swift and TypeScript APIs to use ephemeral key pairs when performing the handshake rather than on initialization.