### PR TITLE
Fix invalid Go version error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/christoffercarlsson/autograph
 
-go 1.22.0
+go 1.22
 
 require golang.org/x/crypto v0.21.0
-
 require golang.org/x/sys v0.18.0 // indirect


### PR DESCRIPTION
This PR fixes the following error when using the Go package as a dependency:

`parsing go.mod: go.mod:3: invalid go version '1.22.0': must match format 1.23`