### PR TITLE
Respect crates.io keyword limit

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,17 +10,7 @@ keywords = [
     "identity",
     "cryptography",
     "privacy",
-    "authentication",
-    "freedom",
-    "verification",
-    "ed25519",
-    "hkdf",
-    "x25519",
-    "chacha20-poly1305",
-    "elliptic-curves",
-    "ownership",
-    "decentralization",
-    "diffie-hellman"
+    "authentication" 
   ]
 repository = "https://github.com/christoffercarlsson/autograph"
 


### PR DESCRIPTION
This PR updates Cargo.toml to respect the limit for maximum number of keywords on crates.io.